### PR TITLE
Add empty state handling for no search results and update translations

### DIFF
--- a/frontend/src/i18n/translations.ts
+++ b/frontend/src/i18n/translations.ts
@@ -43,6 +43,8 @@ export const translations = {
       error_geo:           'Unable to get your location. Please enter your address manually.',
       error_fetch:         'Failed to fetch recommendations. Please try again.',
       error_geo_unsupported: 'Geolocation is not supported by your browser.',
+      no_results_title: "No emergency rooms found nearby",
+      no_results_body: "No ERs were found within the search radius. Try a different address or a more central location.",
     },
     feedback: {
       inline_cta:          'Share your feedback',
@@ -223,6 +225,8 @@ export const translations = {
       error_geo:           "Impossible d'obtenir votre position. Veuillez entrer votre adresse manuellement.",
       error_fetch:         'Échec de la récupération. Veuillez réessayer.',
       error_geo_unsupported: "La géolocalisation n'est pas supportée par votre navigateur.",
+      no_results_title: "Aucune urgence trouvée à proximité",
+      no_results_body: "Aucune urgence n'a été trouvée dans le rayon de recherche. Essayez une adresse différente ou un emplacement plus central.",
     },
     feedback: {
       inline_cta:          'Donnez votre avis',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1672,3 +1672,29 @@ body {
 .chart-card {
   height: 100%;
 }
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.empty-state-icon {
+  color: var(--border);
+}
+
+.empty-state-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.empty-state-body {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin: 0;
+  max-width: 360px;
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -12,12 +12,15 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [locating, setLocating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false); // ← #1
 
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!address.trim()) return;
     setLoading(true);
     setError(null);
+    setResults([]);        // ← #1 clear stale results before each new search
+    setHasSearched(false); // ← #1 reset flag so empty state doesn't flash prematurely
     try {
       let lat: number, lng: number;
       if (coords) {
@@ -38,6 +41,7 @@ export default function Home() {
       }
       const res = await getRecommendations(lat, lng);
       setResults(res.data.results);
+      setHasSearched(true); // ← #1 mark search as completed (whether results or empty)
     } catch {
       setError(t.home.error_fetch);
     } finally {
@@ -168,6 +172,24 @@ export default function Home() {
         </form>
         {error && <p className="error-msg">{error}</p>}
       </section>
+
+      {/* ← #1 Empty state — only shown after a completed search with zero results */}
+      {!loading && hasSearched && results.length === 0 && !error && (
+        <section className="results-section">
+          <div className="empty-state">
+            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="empty-state-icon">
+              <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
+              <circle cx="12" cy="10" r="3"/>
+            </svg>
+            <p className="empty-state-title">
+              {t.home.no_results_title}
+            </p>
+            <p className="empty-state-body">
+              {t.home.no_results_body}
+            </p>
+          </div>
+        </section>
+      )}
 
       {/* Results */}
       {results.length > 0 && (


### PR DESCRIPTION
- Closes #31 
- Empty research results returns a message informing user
- update search state on page 